### PR TITLE
Fix for TAN creating multiple AttackEntityEvent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "0.11"
+version = "0.12"
 group= "io.github.xcube16.iseedragons" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ISeeDragons"
 

--- a/src/main/java/io/github/xcube16/iseedragons/FakeThirstStatHandler.java
+++ b/src/main/java/io/github/xcube16/iseedragons/FakeThirstStatHandler.java
@@ -1,0 +1,128 @@
+package io.github.xcube16.iseedragons;
+
+import java.lang.reflect.Method;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.living.LivingEvent.LivingJumpEvent;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import net.minecraftforge.event.entity.player.AttackEntityEvent;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class FakeThirstStatHandler
+{
+	Object handler;
+	boolean initialized = false;
+	Method onPlayerJump;
+	Method onPlayerHurt;
+	Method onBlockBreak;
+	
+	Method getThirstData;
+	
+	Class thirstHandlerClass;
+	Method addExhaustion;
+	
+	public FakeThirstStatHandler(Object handler)
+	{
+		this.handler = handler;
+		try
+		{
+			onPlayerJump = handler.getClass().getMethod("onPlayerJump", LivingJumpEvent.class);
+			onPlayerHurt = handler.getClass().getMethod("onPlayerHurt", LivingHurtEvent.class);
+			onBlockBreak = handler.getClass().getMethod("onBlockBreak", BlockEvent.BreakEvent.class);
+			
+			getThirstData = Class.forName("toughasnails.api.thirst.ThirstHelper").getMethod("getThirstData", EntityPlayer.class);
+			
+			thirstHandlerClass = Class.forName("toughasnails.thirst.ThirstHandler");
+			addExhaustion = thirstHandlerClass.getMethod("addExhaustion", float.class);
+			
+			//No exceptions, report as successfully initialized
+			initialized = true;
+		}
+		catch(Exception e)
+		{
+			ISeeDragons.logger.error("Failed to initialize FakeThirstStatHandler");
+		}
+	}
+	
+	@SubscribeEvent
+	public void onPlayerJump(LivingJumpEvent event)
+	{
+		if(!initialized)
+			return;
+		try 
+		{
+			onPlayerJump.invoke(handler, event);
+		} 
+		catch (Exception e) 
+		{
+			failMethod(e);
+		}
+	}
+	
+	@SubscribeEvent
+	public void onPlayerHurt(LivingHurtEvent event)
+	{
+		if(!initialized)
+			return;
+		try 
+		{
+			onPlayerHurt.invoke(handler, event);
+		} 
+		catch (Exception e) 
+		{
+			failMethod(e);
+		}
+	}
+	
+	@SubscribeEvent
+	public void onBlockBreak(BlockEvent.BreakEvent event)
+	{
+		if(!initialized)
+			return;
+		try 
+		{
+			onBlockBreak.invoke(handler, event);
+		} 
+		catch (Exception e) 
+		{
+			failMethod(e);
+		}
+	}
+	
+	@SubscribeEvent
+	public void onAttackEntity(AttackEntityEvent event)
+	{
+		if(!initialized)
+			return;
+		try 
+		{
+			World world = event.getEntity().world;
+			if(world.isRemote)
+				return;
+			EntityPlayer player = event.getEntityPlayer();
+			Entity monster = event.getTarget();
+			if(monster.canBeAttackedWithItem() && !player.isCreative() && !monster.hitByEntity(player))
+			{
+				Object thirstHandler = thirstHandlerClass.cast(getThirstData.invoke(null,player));
+				addExhaustion.invoke(thirstHandler, 0.3F);
+			}
+		}
+		catch (Exception e)
+		{
+			failMethod(e);
+		}
+		
+	}
+	
+	private void failMethod(Exception e)
+	{
+		initialized = false;
+		ISeeDragons.logger.error("FakeThirstStatHandler failed reflection");
+		e.printStackTrace();
+	}
+}

--- a/src/main/java/io/github/xcube16/iseedragons/FakeThirstStatHandler.java
+++ b/src/main/java/io/github/xcube16/iseedragons/FakeThirstStatHandler.java
@@ -104,7 +104,6 @@ public class FakeThirstStatHandler
 	private void failMethod(Exception e)
 	{
 		//Reflection failure, print out the stack trace and cause runtime exception
-		e.printStackTrace();
-		throw new RuntimeException("FakeThirstStatHandler failed reflection");
+		throw new RuntimeException("FakeThirstStatHandler failed reflection", e);
 	}
 }

--- a/src/main/java/io/github/xcube16/iseedragons/ISeeDragons.java
+++ b/src/main/java/io/github/xcube16/iseedragons/ISeeDragons.java
@@ -131,12 +131,22 @@ public class ISeeDragons {
             {
                 if (listener_entry.getKey().getClass().getName().equals("toughasnails.handler.thirst.ThirstStatHandler"))
                 {
+                    found_listener=true;
                     //Create the FakeThirstStatHandler and send it the real one to use
-                    MinecraftForge.EVENT_BUS.register(new FakeThirstStatHandler(listener_entry.getKey()));
+                    try 
+                    {
+                        MinecraftForge.EVENT_BUS.register(new FakeThirstStatHandler(listener_entry.getKey()));
+                    } 
+                    catch (Exception e) 
+                    {
+                        //If an exception is thrown, FakeThirstStatHandler never gets added to the event bus
+                        ISeeDragons.logger.error("Failed to initialize FakeThirstStatHandler");
+                        e.printStackTrace();
+                        break;
+                    }
                     
                     //Unregister the real ThirstStatHandler
                     MinecraftForge.EVENT_BUS.unregister(listener_entry.getKey());
-                    found_listener=true;
                     break;
                 }
             }

--- a/src/main/java/io/github/xcube16/iseedragons/ISeeDragons.java
+++ b/src/main/java/io/github/xcube16/iseedragons/ISeeDragons.java
@@ -26,12 +26,16 @@ import net.minecraftforge.event.entity.EntityStruckByLightningEvent;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.EventBus;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.IEventListener;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.EntityRegistry;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,16 +43,18 @@ import org.apache.logging.log4j.Logger;
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Mod(modid= ISeeDragons.MODID, version = ISeeDragons.VERSION, acceptableRemoteVersions = "*", name = ISeeDragons.NAME)
 public class ISeeDragons {
     public static final String MODID = "iseedragons";
     public static final String NAME = "ISeeDragons";
-    public static final String VERSION = "0.11";
+    public static final String VERSION = "0.12";
     public static final Logger logger = LogManager.getLogger(NAME);
 
     @Nullable // lazy init
@@ -79,6 +85,7 @@ public class ISeeDragons {
         MinecraftForge.EVENT_BUS.register(this);
     }
 
+    @SuppressWarnings("deprecation")
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
 
@@ -114,6 +121,31 @@ public class ISeeDragons {
             }
         });
 
+        if(StaticConfig.preventTANAttackEntityEvent && Loader.isModLoaded("toughasnails"))
+        {
+            logger.info("Fixing TAN's attack entity event damage problem...");
+            boolean found_listener = false;
+            //Find the ThirstStatHandler in the event bus and remove it
+            ConcurrentHashMap<Object, ArrayList<IEventListener>> listeners = ReflectionHelper.getPrivateValue(EventBus.class, MinecraftForge.EVENT_BUS, "listeners");
+            for(Map.Entry<Object, ArrayList<IEventListener>> listener_entry : listeners.entrySet())
+            {
+                if (listener_entry.getKey().getClass().getName().equals("toughasnails.handler.thirst.ThirstStatHandler"))
+                {
+                    //Create the FakeThirstStatHandler and send it the real one to use
+                    MinecraftForge.EVENT_BUS.register(new FakeThirstStatHandler(listener_entry.getKey()));
+                    
+                    //Unregister the real ThirstStatHandler
+                    MinecraftForge.EVENT_BUS.unregister(listener_entry.getKey());
+                    found_listener=true;
+                    break;
+                }
+            }
+            if(!found_listener)
+            {
+                logger.error("Could not find toughasnails ThirstStatHandler event listener");
+                return;
+            }
+        }
     }
 
     private void fixToolRepair(String toolId, String repairItemId, int meta) {

--- a/src/main/java/io/github/xcube16/iseedragons/StaticConfig.java
+++ b/src/main/java/io/github/xcube16/iseedragons/StaticConfig.java
@@ -29,6 +29,7 @@ public class StaticConfig {
     public static boolean disableLightningItemDamage = false;
 
     @Config.Comment("Prevents Tough As Nails from creating an extra attack entity event")
+    @Config.RequiresMcRestart
     public static boolean preventTANAttackEntityEvent = true;
 
     @Config.Comment("A list of block drop % chances")

--- a/src/main/java/io/github/xcube16/iseedragons/StaticConfig.java
+++ b/src/main/java/io/github/xcube16/iseedragons/StaticConfig.java
@@ -28,6 +28,9 @@ public class StaticConfig {
     @Config.Comment("Prevents lightning strikes from destroying items")
     public static boolean disableLightningItemDamage = false;
 
+    @Config.Comment("Prevents Tough As Nails from creating an extra attack entity event")
+    public static boolean preventTANAttackEntityEvent = true;
+
     @Config.Comment("A list of block drop % chances")
     @Config.Name("DropChances")
     public static Map<String, Integer> dropChances;

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "iseedragons",
   "name": "ISeeDragons",
   "description": "Fix Ice and Fire dragon render distance and some other Ice and Fire 1.7.* bugs!",
-  "version": "1.12.2-0.11",
+  "version": "1.12.2-0.12",
   "mcversion": "1.12.2",
   "url": "https://github.com/xcube16/ISeeDragons",
   "updateUrl": "",


### PR DESCRIPTION
This bug was causing lots of strange damage calculation, for example the silver weapon damage buff getting applied twice and SpartanWeaponry doing too much damage.

The old thirst event handler is located, unregistered, and stored in a fake thirst event handler, which gets registered in its place. The fake one has the old one continue its duties, but takes care of AttackEntityEvent itself.